### PR TITLE
Restructure components

### DIFF
--- a/Levels/AnimationExample/level.xml
+++ b/Levels/AnimationExample/level.xml
@@ -4,7 +4,7 @@
 		<entity>
 			<player />
 			<renderable meshName="Cube" program="normalMapped"/>
-			<transform x="13" y="2" z="90" />
+			<transform positionX="13" positionY="2" positionZ="90" />
 		</entity>
 		<!-- <entity>
 			<renderable name="skybox" program="deferredWithLightScattering" />

--- a/Levels/AnimationExample/level.xml
+++ b/Levels/AnimationExample/level.xml
@@ -2,7 +2,7 @@
 <level name="AnimationExample">
 	<scene file="Anim.dae">
 		<entity>
-			<player />
+			<player cameraOffset="20.0"/>
 			<renderable meshName="Cube" program="normalMapped"/>
 			<transform positionX="13" positionY="2" positionZ="90" />
 		</entity>

--- a/Levels/TestLevel/level.xml
+++ b/Levels/TestLevel/level.xml
@@ -1,6 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <level name="TestLevel">
 	<scene file="Warehouse_Full.fbx">
+		<entity>
+			<player cameraOffset="8.0" />
+			<renderable meshName="LightBulb"/>
+			<!-- <transform positionX="0.0" positionY="12.0" positionZ="0" orientationX="0.0"/> -->
+			<!-- <light quadraticAttenuation="1.0"/> -->
+		</entity>
+		<entity name="Sun">
+			<renderable meshName="Skybox" program="Skybox"/>
+		</entity>
 		<!-- <entity>
 			<player />
 			<renderable meshName="Cube" program="normalMapped"/>
@@ -11,11 +20,12 @@
 		</entity> -->
 	</scene>
 	<scene file="falcon.fbx">
-		<entity>
-			<player/>
+		<!-- <entity>
+			<player cameraOffset="8.0" />
 			<renderable meshName="Body"/>
-			<transform positionX="0.0" positionY="12.0" positionZ="0" orientationX="3.14"/>
-		</entity>
+			<transform positionX="0.0" positionY="12.0" positionZ="0" orientationX="0.0"/>
+			<light quadraticAttenuation="1.0"/>
+		</entity> -->
 	</scene>
 	<!-- <scene file="player.fbx">
 		<entity>

--- a/Levels/TestLevel/level.xml
+++ b/Levels/TestLevel/level.xml
@@ -14,6 +14,7 @@
 		<entity>
 			<player/>
 			<renderable meshName="Body"/>
+			<transform positionX="0.0" positionY="12.0" positionZ="0" orientationX="3.14"/>
 		</entity>
 	</scene>
 	<!-- <scene file="player.fbx">

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,21 @@ CC = g++ -g -std=c++11 -c $(CFLG) -I$(INC) -o $@ $<
 
 $(OBJDIR)Main.o: $(SRC)/Main.cpp
 	$(CC)
-$(OBJDIR)ComponentManager.o: $(SRC)/GameEngine/ComponentManager.cpp $(INC)/ComponentManager.h $(INC)/Component.h
+$(OBJDIR)ComponentManager.o: $(SRC)/GameEngine/ComponentManager.cpp $(INC)/ComponentManager.h $(INC)/Components/Component.h
 	$(CC)
+$(OBJDIR)Renderable.o: $(SRC)/GameEngine/Components/Renderable.cpp $(INC)/Components/Renderable.h $(INC)/Components/Component.h
+	$(CC)
+$(OBJDIR)Transform.o: $(SRC)/GameEngine/Components/Transform.cpp $(INC)/Components/Transform.h $(INC)/Components/Component.h
+	$(CC)
+$(OBJDIR)Player.o: $(SRC)/GameEngine/Components/Player.cpp $(INC)/Components/Player.h $(INC)/Components/Component.h
+	$(CC)
+$(OBJDIR)SkinnedRenderable.o: $(SRC)/GameEngine/Components/SkinnedRenderable.cpp $(INC)/Components/SkinnedRenderable.h $(INC)/Components/Component.h
+	$(CC)
+$(OBJDIR)Light.o: $(SRC)/GameEngine/Components/Light.cpp $(INC)/Components/Light.h $(INC)/Components/Component.h
+	$(CC)
+$(OBJDIR)ParticleSystem.o: $(SRC)/GameEngine/Components/ParticleSystem.cpp $(INC)/Components/ParticleSystem.h $(INC)/Components/Component.h
+	$(CC)
+
 $(OBJDIR)EntityManager.o: $(SRC)/GameEngine/EntityManager.cpp $(INC)/EntityManager.h
 	$(CC)
 $(OBJDIR)MessageManager.o: $(SRC)/GameEngine/MessageManager.cpp $(INC)/MessageManager.h
@@ -76,7 +89,7 @@ $(OBJDIR)TinyXMLAdapter.o: $(SRC)/LevelLoader/TinyXMLAdapter.cpp $(INC)/TinyXMLA
 # 	g++ -g -std=c++11 -c $(CFLG) -I$(INC) $^
 
 
-Pegasus: $(OBJDIR)Main.o $(OBJDIR)ComponentManager.o $(OBJDIR)EntityManager.o $(OBJDIR)MessageManager.o $(OBJDIR)System.o  $(OBJDIR)ECSEngine.o $(OBJDIR)LevelLoader.o $(OBJDIR)SceneLoader.o $(OBJDIR)TextureLoader.o $(OBJDIR)ShaderManager.o $(OBJDIR)Gameplay.o $(OBJDIR)RenderSystem.o $(OBJDIR)FrameBuffer.o $(OBJDIR)PlayerMovementSystem.o $(OBJDIR)Animation.o $(OBJDIR)AnimationSystem.o $(OBJDIR)XMLAdapterFactory.o $(OBJDIR)TinyXMLAdapter.o
+Pegasus: $(OBJDIR)Main.o $(OBJDIR)ComponentManager.o $(OBJDIR)EntityManager.o $(OBJDIR)MessageManager.o $(OBJDIR)System.o  $(OBJDIR)ECSEngine.o $(OBJDIR)LevelLoader.o $(OBJDIR)SceneLoader.o $(OBJDIR)TextureLoader.o $(OBJDIR)ShaderManager.o $(OBJDIR)Gameplay.o $(OBJDIR)RenderSystem.o $(OBJDIR)FrameBuffer.o $(OBJDIR)PlayerMovementSystem.o $(OBJDIR)Animation.o $(OBJDIR)AnimationSystem.o $(OBJDIR)XMLAdapterFactory.o $(OBJDIR)TinyXMLAdapter.o $(OBJDIR)Renderable.o $(OBJDIR)Transform.o $(OBJDIR)Player.o $(OBJDIR)SkinnedRenderable.o $(OBJDIR)Light.o $(OBJDIR)ParticleSystem.o
 	g++ -O3 -o $@ $^ $(LIBS)
 
 clean:

--- a/Shaders/Skybox.frag
+++ b/Shaders/Skybox.frag
@@ -22,5 +22,5 @@ void main() {
 	diffuse.rgb = texture(colorTexture, texCoords).rgb;
 	diffuse.a = shininess;
 	emissive = texture(emissiveTexture, texCoords);
-	occlusion = vec4(vec3(0.0),1.0);
+	occlusion = texture(emissiveTexture, texCoords);
 }

--- a/Shaders/deferredNormalMapped.frag
+++ b/Shaders/deferredNormalMapped.frag
@@ -4,6 +4,7 @@ layout (location = 0) out vec4 position;
 layout (location = 1) out vec4 normal;
 layout (location = 2) out vec4 diffuse;
 layout (location = 3) out vec4 emissive;
+layout (location = 4) out vec4 occlusion;
 
 
 in vec4 fragPos;
@@ -21,4 +22,5 @@ void main() {
 	diffuse.rgb = texture(colorTexture, texCoords).rgb;
 	diffuse.a = shininess;
 	emissive = texture(emissiveTexture, texCoords);
+	occlusion = vec4(vec3(0.0),1.0);
 }

--- a/headers/AnimationSystem.h
+++ b/headers/AnimationSystem.h
@@ -3,7 +3,7 @@
 
 #include "MessageManager.h"
 #include "ComponentManager.h"
-#include "Component.h"
+#include "Components/SkinnedRenderable.h"
 
 class AnimationSystem : System {
 private:

--- a/headers/ComponentManager.h
+++ b/headers/ComponentManager.h
@@ -2,7 +2,6 @@
 #define COMPONENTMANAGER_H
 
 #include <vector>
-#include "Component.h"
 #include <iostream>
 #include <string>
 #include <vector>

--- a/headers/Components/Component.h
+++ b/headers/Components/Component.h
@@ -1,0 +1,44 @@
+
+#ifndef COMPONENT_H
+#define COMPONENT_H
+
+#define SHADOW_MAP_DIMENSION 2048
+
+#define GL_GLEXT_PROTOTYPES 1
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+#include "MessageManager.h"
+#include <SDL2/SDL_opengl.h>
+#include "Material.h"
+#include "Animation.h"
+#include "XMLParserAdapter.h"
+#include <iostream>
+
+struct Component {
+	int ownerID; // entityID for the entity that owns this component
+	Component(int owner){ownerID = owner;}
+	Component(){}
+	virtual void readFromXML(XmlElement * element) = 0;
+};
+
+// struct Physics:Component {
+// 	glm::vec3 velocity;
+// 	float mass;
+// 	bool freeze; // add this?
+// 	bool onGround; // useful for player movement?
+// };
+
+// struct Collider:Component {
+
+// };
+
+// struct Trigger:Component {
+// 	float radius;
+// 	BasicMessage m;
+// };
+
+// struct Grapple:Component {
+
+// };
+
+#endif

--- a/headers/Components/Component.h
+++ b/headers/Components/Component.h
@@ -18,6 +18,7 @@ struct Component {
 	int ownerID; // entityID for the entity that owns this component
 	Component(int owner){ownerID = owner;}
 	Component(){}
+	virtual ~Component(){}
 	virtual void readFromXML(XmlElement * element) = 0;
 };
 

--- a/headers/Components/Light.h
+++ b/headers/Components/Light.h
@@ -1,4 +1,4 @@
-#ifndef LIGHT_H
+ #ifndef LIGHT_H
 #define LIGHT_H
 
 
@@ -9,6 +9,7 @@ struct Light:Component {
 	glm::vec3 location = glm::vec3(0.0,0.0,0.0);
 	glm::vec3 diffuse = glm::vec3(1.0,0.0,1.0);
 	glm::vec3 specular = glm::vec3(1.0,0.0,1.0);
+	glm::vec3 direction = glm::vec3(-1.0,-1.0,-1.0);
 	float linearAttenuation = 0.0;
 	float quadraticAttenuation = 0.0;
 

--- a/headers/Components/Light.h
+++ b/headers/Components/Light.h
@@ -1,110 +1,8 @@
-
-#ifndef COMPONENT_H
-#define COMPONENT_H
-
-#define SHADOW_MAP_DIMENSION 2048
-
-#define GL_GLEXT_PROTOTYPES 1
-#include <glm/glm.hpp>
-#include <glm/gtc/matrix_transform.hpp>
-#include "MessageManager.h"
-#include <SDL2/SDL_opengl.h>
-#include "Material.h"
-#include "Animation.h"
-#include <iostream>
-
-struct Component {
-	int ownerID; // entityID for the entity that owns this component
-	Component(int owner){ownerID = owner;}
-	Component(){}
-};
+#ifndef LIGHT_H
+#define LIGHT_H
 
 
-struct Transform:Component {
-	glm::vec4 position = glm::vec4(0.0,0.0,0.0,1.0);
-	glm::vec3 orientation = glm::vec3(0.0,0.0,0.0);
-	float scale = 1.0;
-	Transform(glm::vec4& position_in, glm::vec3& orientation_in, float scale_in, int ownerID) : Component(ownerID)
-	{
-		position = position_in;
-		orientation = orientation_in;
-		scale = scale_in;
-	}
-	Transform(){}
-};
-
-struct Renderable:Component {
-	GLuint VBO;
-	GLuint IBO;
-	int numVertices;
-	int program; // index into shadermanager
-	Material material;
-	Renderable(GLuint VBO_in, GLuint IBO_in, int vertex_Count, int program_in, Material & material_in, int ownerID):Component(ownerID)
-	{
-		VBO = VBO_in;
-		IBO = IBO_in;
-		numVertices = vertex_Count;
-		program = program_in;
-		material = material_in;
-	}
-	Renderable(){}
-};
-
-struct SkinnedRenderable:Component {
-	GLuint VBO;
-	GLuint IBO;
-	int numVertices;
-	int program; // index into shadermanager
-	Material material;
-	BoneHierarchy bones;
-	SkinnedRenderable(GLuint VBO_in, GLuint IBO_in, int vertex_Count, int program_in, Material & material_in, int ownerID, BoneHierarchy &bones_in):Component(ownerID)
-	{
-		VBO = VBO_in;
-		IBO = IBO_in;
-		numVertices = vertex_Count;
-		program = program_in;
-		material = material_in;
-		bones = bones_in;
-	}
-	SkinnedRenderable(){}
-	SkinnedRenderable( const SkinnedRenderable &obj)
-	{
-		VBO = obj.VBO;
-		IBO = obj.IBO;
-		numVertices = obj.numVertices;
-		program = obj.program;
-		material = obj.material;
-		bones = obj.bones;
-	}
-};
-
-struct Physics:Component {
-	glm::vec3 velocity;
-	float mass;
-	bool freeze; // add this?
-	bool onGround; // useful for player movement?
-};
-
-struct Collider:Component {
-
-};
-
-struct Trigger:Component {
-	float radius;
-	BasicMessage m;
-};
-
-struct Grapple:Component {
-
-};
-
-struct Player:Component {
-	float cameraOffset = 1.0; //distance from transform of player to camera
-	float cameraYaw = 0;
-	float cameraPitch = 0;
-	//float cameraRoll; // add this later if we want
-	Player(int ownerID):Component(ownerID){}
-};
+#include "Component.h"
 
 struct Light:Component {
 	bool directional = false;
@@ -165,18 +63,8 @@ struct Light:Component {
 		}
 		glBindTexture(GL_TEXTURE_2D, 0);
 	}
-};
 
-struct ParticleSystem:Component {
-	GLuint VBO;
-	int nParticles;
-	int program;
-	ParticleSystem( GLuint VBO_in, int numParts, int program_in ) {
-		VBO = VBO_in;
-		nParticles = numParts;
-		program = program_in;
-	}
-	ParticleSystem(){}
+	void readFromXML(XmlElement * element);
 };
 
 #endif

--- a/headers/Components/ParticleSystem.h
+++ b/headers/Components/ParticleSystem.h
@@ -1,0 +1,19 @@
+#ifndef PARTICLE_SYSTEM_H
+#define PARTICLE_SYSTEM_H
+
+#include "Component.h"
+
+struct ParticleSystem:Component {
+	GLuint VBO;
+	int nParticles;
+	int program;
+	ParticleSystem( GLuint VBO_in, int numParts, int program_in ) {
+		VBO = VBO_in;
+		nParticles = numParts;
+		program = program_in;
+	}
+	ParticleSystem(){}
+	void readFromXML(XmlElement * element);
+};
+
+#endif

--- a/headers/Components/Player.h
+++ b/headers/Components/Player.h
@@ -1,0 +1,16 @@
+#ifndef PLAYER_H
+#define PLAYER_H
+
+#include "Component.h"
+
+struct Player:Component {
+	float cameraOffset = 1.0; //distance from transform of player to camera
+	float cameraYaw = 0;
+	float cameraPitch = 0;
+	//float cameraRoll; // add this later if we want
+	Player(int ownerID):Component(ownerID){}
+
+	void readFromXML(XmlElement * element);
+};
+
+#endif

--- a/headers/Components/Renderable.h
+++ b/headers/Components/Renderable.h
@@ -2,6 +2,7 @@
 #define RENDERABLE_H
 
 #include "Component.h"
+#include "ShaderManager.h"
 
 struct Renderable:Component {
 	GLuint VBO;

--- a/headers/Components/Renderable.h
+++ b/headers/Components/Renderable.h
@@ -1,0 +1,25 @@
+#ifndef RENDERABLE_H
+#define RENDERABLE_H
+
+#include "Component.h"
+
+struct Renderable:Component {
+	GLuint VBO;
+	GLuint IBO;
+	int numVertices;
+	int program; // index into shadermanager
+	Material material;
+	Renderable(GLuint VBO_in, GLuint IBO_in, int vertex_Count, int program_in, Material & material_in, int ownerID):Component(ownerID)
+	{
+		VBO = VBO_in;
+		IBO = IBO_in;
+		numVertices = vertex_Count;
+		program = program_in;
+		material = material_in;
+	}
+	Renderable(){}
+
+	void readFromXML(XmlElement * element);
+};
+
+#endif

--- a/headers/Components/SkinnedRenderable.h
+++ b/headers/Components/SkinnedRenderable.h
@@ -1,0 +1,36 @@
+#ifndef SKINNED_RENDERABLE_H
+#define SKINNED_RENDERABLE_H
+
+#include "Component.h"
+
+struct SkinnedRenderable:Component {
+	GLuint VBO;
+	GLuint IBO;
+	int numVertices;
+	int program; // index into shadermanager
+	Material material;
+	BoneHierarchy bones;
+	SkinnedRenderable(GLuint VBO_in, GLuint IBO_in, int vertex_Count, int program_in, Material & material_in, int ownerID, BoneHierarchy &bones_in):Component(ownerID)
+	{
+		VBO = VBO_in;
+		IBO = IBO_in;
+		numVertices = vertex_Count;
+		program = program_in;
+		material = material_in;
+		bones = bones_in;
+	}
+	SkinnedRenderable(){}
+	SkinnedRenderable( const SkinnedRenderable &obj)
+	{
+		VBO = obj.VBO;
+		IBO = obj.IBO;
+		numVertices = obj.numVertices;
+		program = obj.program;
+		material = obj.material;
+		bones = obj.bones;
+	}
+
+	void readFromXML(XmlElement * element);
+};
+
+#endif

--- a/headers/Components/Transform.h
+++ b/headers/Components/Transform.h
@@ -1,0 +1,21 @@
+#ifndef TRANSFORM_H
+#define TRANSFORM_H
+
+#include "Component.h"
+
+struct Transform:Component {
+	glm::vec4 position = glm::vec4(0.0,0.0,0.0,1.0);
+	glm::vec3 orientation = glm::vec3(0.0,0.0,0.0);
+	float scale = 1.0;
+	Transform(glm::vec4& position_in, glm::vec3& orientation_in, float scale_in, int ownerID) : Component(ownerID)
+	{
+		position = position_in;
+		orientation = orientation_in;
+		scale = scale_in;
+	}
+	Transform(){}
+
+	void readFromXML(XmlElement * element);
+};
+
+#endif

--- a/headers/ECSEngine.h
+++ b/headers/ECSEngine.h
@@ -6,7 +6,14 @@
 #include "System.h"
 #include "ComponentManager.h"
 #include "EntityManager.h"
-#include "Component.h"
+
+#include "Components/Transform.h"
+#include "Components/Renderable.h"
+#include "Components/Player.h"
+#include "Components/Light.h"
+#include "Components/SkinnedRenderable.h"
+#include "Components/ParticleSystem.h"
+
 #include "ShaderManager.h"
 #include "RenderSystem.h"
 #include "PlayerMovementSystem.h"

--- a/headers/ECSEngine.h
+++ b/headers/ECSEngine.h
@@ -54,6 +54,13 @@ public:
 	void addParticleSystem(int entityID, ParticleSystem &comp);
 	RenderSystem* getRenderSystem();
 
+	ComponentManager<Transform> * getTransformManager();
+	ComponentManager<Renderable> * getRenderableManager();
+	ComponentManager<Player> * getPlayerManager();
+	ComponentManager<Light> * getLightManager();
+	ComponentManager<SkinnedRenderable> * getSkinnedRenderableManager();
+	ComponentManager<ParticleSystem> * getParticleSystemManager();
+
 	static ECSEngine * createECS();
 
 

--- a/headers/EntityManager.h
+++ b/headers/EntityManager.h
@@ -3,6 +3,7 @@
 
 #include <iostream>
 #include <cstring>
+#include <map>
 
 
 struct Entity {
@@ -14,6 +15,7 @@ struct Entity {
 class EntityManager {
 private:
 	Entity* entities; // might need to change this later
+	std::map<std::string, int> namedEntities;
 	int arraySize;
 	int minAvailable;
 	void increaseArraySize(int size);
@@ -22,9 +24,11 @@ public:
 	EntityManager();
 	~EntityManager();
 	int createEntity(); //returns entityID for the created entity
+	int createEntity(char * name);
 	void killEntity(int entityID);
 	bool isAlive(int entityID);
 	void print();
+	int getEntityID(std::string & name);
 
 };
 

--- a/headers/LevelLoader.h
+++ b/headers/LevelLoader.h
@@ -12,7 +12,12 @@
 #define GL_GLEXT_PROTOTYPES 1
 #include "ShaderManager.h"
 #include "Material.h"
-#include "Component.h"
+
+#include "Components/Light.h"
+#include "Components/Transform.h"
+#include "Components/Renderable.h"
+#include "Components/SkinnedRenderable.h"
+
 #include "ECSEngine.h"
 #include "Animation.h"
 #include "XMLParserAdapter.h"
@@ -46,7 +51,6 @@ private:
 public:
 	LevelLoader();
 	void openLevel(std::string & directory, ECSEngine * engine); 
-	void testLevel(ECSEngine * engine); // hardcoded version of openLevel(). used for testing and allowing development of the game's systems to begin and be tested
 };
 
 

--- a/headers/PlayerMovementSystem.h
+++ b/headers/PlayerMovementSystem.h
@@ -2,7 +2,8 @@
 #define PLAYERMOVEMENT_H
 
 #include <SDL2/SDL.h>
-#include "Component.h"
+#include "Components/Transform.h"
+#include "Components/Player.h"
 #include "ComponentManager.h"
 #include "System.h"
 

--- a/headers/RenderSystem.h
+++ b/headers/RenderSystem.h
@@ -6,7 +6,13 @@
 #include <SDL2/SDL.h>
 #include <cstdlib>
 #include "ComponentManager.h"
-#include "Component.h"
+#include "Components/Renderable.h"
+#include "Components/Transform.h"
+#include "Components/SkinnedRenderable.h"
+#include "Components/Light.h"
+#include "Components/Player.h"
+#include "Components/ParticleSystem.h"
+
 #include "System.h"
 #include "MessageManager.h"
 #include "ShaderManager.h"

--- a/headers/ShaderManager.h
+++ b/headers/ShaderManager.h
@@ -6,7 +6,9 @@
 #include <SDL2/SDL_opengl.h>
 #include <vector>
 #include <iostream>
-#include "Component.h"
+#include "Components/Light.h"
+#include "Components/Transform.h"
+
 #include "Material.h"
 #include "Animation.h"
 #include <glm/mat4x4.hpp> 

--- a/headers/ShaderManager.h
+++ b/headers/ShaderManager.h
@@ -144,6 +144,7 @@ public:
 	static int testShadowsDirectional;
 	static int displayParticles;
 	static int volumetricLightScattering;
+	static int skybox;
 };
 
 // static int hdrProgram;

--- a/source/GameEngine/Components/Light.cpp
+++ b/source/GameEngine/Components/Light.cpp
@@ -16,4 +16,8 @@ void Light::readFromXML(XmlElement * element) {
 	element->queryFloatAttribute("specularGreen",&specular.y);
 	element->queryFloatAttribute("specularBlue",&specular.z);
 
+	element->queryFloatAttribute("directionX",&direction.x);
+	element->queryFloatAttribute("directionY",&direction.y);
+	element->queryFloatAttribute("directionZ",&direction.z);
+
 }

--- a/source/GameEngine/Components/Light.cpp
+++ b/source/GameEngine/Components/Light.cpp
@@ -1,0 +1,5 @@
+#include "Components/Light.h"
+
+void Light::readFromXML(XmlElement * element) {
+	
+}

--- a/source/GameEngine/Components/Light.cpp
+++ b/source/GameEngine/Components/Light.cpp
@@ -1,5 +1,19 @@
 #include "Components/Light.h"
 
 void Light::readFromXML(XmlElement * element) {
-	
+	element->queryFloatAttribute("linearAttenuation",&linearAttenuation);
+	element->queryFloatAttribute("quadraticAttenuation",&quadraticAttenuation);
+
+	element->queryFloatAttribute("locationOffsetX",&location.x);
+	element->queryFloatAttribute("locationOffsetY",&location.y);
+	element->queryFloatAttribute("locationOffsetZ",&location.z);
+
+	element->queryFloatAttribute("diffuseRed",&diffuse.x);
+	element->queryFloatAttribute("diffuseGreen",&diffuse.y);
+	element->queryFloatAttribute("diffuseBlue",&diffuse.z);
+
+	element->queryFloatAttribute("specularRed",&specular.x);
+	element->queryFloatAttribute("specularGreen",&specular.y);
+	element->queryFloatAttribute("specularBlue",&specular.z);
+
 }

--- a/source/GameEngine/Components/ParticleSystem.cpp
+++ b/source/GameEngine/Components/ParticleSystem.cpp
@@ -1,0 +1,5 @@
+#include "Components/ParticleSystem.h"
+
+void ParticleSystem::readFromXML(XmlElement * element) {
+	
+}

--- a/source/GameEngine/Components/Player.cpp
+++ b/source/GameEngine/Components/Player.cpp
@@ -1,5 +1,7 @@
 #include "Components/Player.h"
 
 void Player::readFromXML(XmlElement * element) {
-	
+	element->queryFloatAttribute("cameraOffset",&cameraOffset);
+	element->queryFloatAttribute("cameraYaw",&cameraYaw);
+	element->queryFloatAttribute("cameraPitch",&cameraPitch);
 }

--- a/source/GameEngine/Components/Player.cpp
+++ b/source/GameEngine/Components/Player.cpp
@@ -1,0 +1,5 @@
+#include "Components/Player.h"
+
+void Player::readFromXML(XmlElement * element) {
+	
+}

--- a/source/GameEngine/Components/Renderable.cpp
+++ b/source/GameEngine/Components/Renderable.cpp
@@ -1,0 +1,5 @@
+#include "Components/Renderable.h"
+
+void Renderable::readFromXML(XmlElement * element) {
+	
+}

--- a/source/GameEngine/Components/Renderable.cpp
+++ b/source/GameEngine/Components/Renderable.cpp
@@ -2,12 +2,9 @@
 
 void Renderable::readFromXML(XmlElement * element) {
 	char * programName = NULL;
-	std::cout << "reading renderable" << std::endl;
 	element->queryStringAttribute("program",(const char**)&programName);
-	//std::cout << "Renderable with programName: " << programName << std::endl;
 	if(programName != NULL) {
 		if(strcmp(programName, "Skybox") == 0) {
-			std::cout << "      - Using Skybox program" << std::endl;
 			program = ShaderManager::skybox;
 		}
 	}

--- a/source/GameEngine/Components/Renderable.cpp
+++ b/source/GameEngine/Components/Renderable.cpp
@@ -1,5 +1,14 @@
 #include "Components/Renderable.h"
 
 void Renderable::readFromXML(XmlElement * element) {
-	
+	char * programName = NULL;
+	std::cout << "reading renderable" << std::endl;
+	element->queryStringAttribute("program",(const char**)&programName);
+	//std::cout << "Renderable with programName: " << programName << std::endl;
+	if(programName != NULL) {
+		if(strcmp(programName, "Skybox") == 0) {
+			std::cout << "      - Using Skybox program" << std::endl;
+			program = ShaderManager::skybox;
+		}
+	}
 }

--- a/source/GameEngine/Components/SkinnedRenderable.cpp
+++ b/source/GameEngine/Components/SkinnedRenderable.cpp
@@ -1,0 +1,5 @@
+#include "Components/SkinnedRenderable.h"
+
+void SkinnedRenderable::readFromXML(XmlElement * element) {
+	
+}

--- a/source/GameEngine/Components/Transform.cpp
+++ b/source/GameEngine/Components/Transform.cpp
@@ -1,5 +1,17 @@
 #include "Components/Transform.h"
 
 void Transform::readFromXML(XmlElement * element) {
-	
+
+	// fill in position data
+	element->queryFloatAttribute("positionX",&position.x);
+	element->queryFloatAttribute("positionY",&position.y);
+	element->queryFloatAttribute("positionZ",&position.z);
+	element->queryFloatAttribute("positionW",&position.w);
+
+	//fill in orientation data
+	element->queryFloatAttribute("orientationX",&orientation.x);
+	element->queryFloatAttribute("orientationY",&orientation.y);
+	element->queryFloatAttribute("orientationZ",&orientation.z);
+
+	element->queryFloatAttribute("scale",&scale);
 }

--- a/source/GameEngine/Components/Transform.cpp
+++ b/source/GameEngine/Components/Transform.cpp
@@ -1,0 +1,5 @@
+#include "Components/Transform.h"
+
+void Transform::readFromXML(XmlElement * element) {
+	
+}

--- a/source/GameEngine/ECSEngine.cpp
+++ b/source/GameEngine/ECSEngine.cpp
@@ -68,6 +68,13 @@ void ECSEngine::addParticleSystem(int entityID, ParticleSystem &comp)
 	particleManager.addComponent(entityID, comp);
 }
 
+ComponentManager<Transform> * ECSEngine::getTransformManager(){return &transformManager;}
+ComponentManager<Renderable> * ECSEngine::getRenderableManager(){return &renderableManager;}
+ComponentManager<Player> * ECSEngine::getPlayerManager(){return &playerManager;}
+ComponentManager<Light> * ECSEngine::getLightManager(){return &lightManager;}
+ComponentManager<SkinnedRenderable> * ECSEngine::getSkinnedRenderableManager(){return &skinnedManager;}
+ComponentManager<ParticleSystem> * ECSEngine::getParticleSystemManager(){return &particleManager;}
+
 RenderSystem* ECSEngine::getRenderSystem()
 {
 	return &rendersystemObject;

--- a/source/GameEngine/EntityManager.cpp
+++ b/source/GameEngine/EntityManager.cpp
@@ -35,8 +35,16 @@ int EntityManager::createEntity() //returns entityID for the created entity
 	}
 
 	return created;
-
 }
+
+int EntityManager::createEntity(char * name) //returns entityID for the created entity
+{
+	int entityID = createEntity();
+	std::string nameString(name);
+	namedEntities.insert(std::pair<std::string,int>(nameString,entityID));
+	return entityID;
+}
+
 void EntityManager::killEntity(int entityID)
 {
 	if(entityID < arraySize)
@@ -46,7 +54,21 @@ void EntityManager::killEntity(int entityID)
 			minAvailable = entityID;
 	}
 
+	for (std::pair<std::string, int> element : namedEntities) {
+		// Accessing KEY from element
+		std::string name = element.first;
+		// Accessing VALUE from element.
+		int elementId = element.second;
+		if(elementId == entityID) {
+			namedEntities.erase(name);
+		}
+	}
 }
+
+int EntityManager::getEntityID(std::string & name) {
+	return namedEntities.find(name)->second;
+}
+
 bool EntityManager::isAlive(int entityID)
 {
 	if(entityID >= arraySize)

--- a/source/GameEngine/Systems/Animation.cpp
+++ b/source/GameEngine/Systems/Animation.cpp
@@ -288,7 +288,7 @@ void BoneHierarchy::updateAnimation(double dt)
 		while(currentTime > animations[currentAnimation].animationLength)
 			currentTime -= animations[currentAnimation].animationLength;
 		glm::mat4 temp = glm::mat4(1.0);
-		setCurrentTransform(root, glm::rotate(glm::mat4(1.0), -3.14f, glm::vec3(1.0,0.0,0.0)) * baseOffset);//glm::mat4(1.0));
+		setCurrentTransform(root, glm::rotate(glm::mat4(1.0), -3.14f, glm::vec3(1.0,0.0,0.0)) /* baseOffset*/);//glm::mat4(1.0));
 	}
 	//std::cout << root << std::endl;
 	

--- a/source/GameEngine/Systems/RenderSystem.cpp
+++ b/source/GameEngine/Systems/RenderSystem.cpp
@@ -285,7 +285,10 @@ void RenderSystem::update()
 
 	if(sun && sunLoc)
 	{
-		glm::vec4 lightScreenLoc = projection * view * (glm::vec4(sun->location,0.0) + sunLoc->position / sunLoc->position.w);
+		glm::vec4 lightScreenLoc;
+		if(sun->directional)
+			lightScreenLoc = projection * view * (glm::vec4(cameraLoc + sun->direction * -100.0f,1.0));
+		else lightScreenLoc = projection * view * (glm::vec4(sun->location,0.0) + sunLoc->position / sunLoc->position.w);
 		// only apply volumetric light scattering if looking towards the light emitting it
 		if(lightScreenLoc.w > 0.0f)
 		{
@@ -302,7 +305,7 @@ void RenderSystem::update()
 		
 			shaders->bindShader(ShaderManager::volumetricLightScattering);
 			bloomTarget.bindFrameBuffer();
-			deferredShadingData.bindTexture(emissiveTexture, GL_TEXTURE0); // use occlusionTexture for actual volumetric light scattering
+			deferredShadingData.bindTexture(occlusionTexture, GL_TEXTURE0); // use occlusionTexture for actual volumetric light scattering
 			
 			//load uniforms
 			glUniform2f(sunScreenCoordLoc, lightScreenLoc.x, lightScreenLoc.y);
@@ -341,7 +344,7 @@ void RenderSystem::update()
 
 
 
-	// // debugging test render normals to double check correctness
+	// debugging test render normals to double check correctness
 	// glBindFramebuffer(GL_FRAMEBUFFER, 0);
 	// shaders->bindShader(4);
 	// deferredShadingData.bindTexture(occlusionTexture, GL_TEXTURE0);

--- a/source/LevelLoader/LevelLoader.cpp
+++ b/source/LevelLoader/LevelLoader.cpp
@@ -82,15 +82,15 @@ void LevelLoader::loadEntity(XmlElement * entity, Scene * scene, ECSEngine * eng
 	else entityID = engine->addEntity();
 	std::cout << "   - entityID: " << entityID << std::endl;
 
-	XmlElement * player = entity->firstChild("player");
-	if(player != NULL) {
+	XmlElement * playerElement = entity->firstChild("player");
+	if(playerElement != NULL) {
 		std::cout << "   - Adding Player" << std::endl;
-		Player p = Player(entityID);
+		Player player = Player(entityID);
 
-		p.cameraOffset = 8;
-		engine->addPlayer(entityID,p);
+		player.readFromXML(playerElement);
+		engine->addPlayer(entityID,player);
 		verification.hasPlayer = true;
-		delete player;
+		delete playerElement;
 	}
 
 	XmlElement * transformElement = entity->firstChild("transform");
@@ -105,6 +105,20 @@ void LevelLoader::loadEntity(XmlElement * entity, Scene * scene, ECSEngine * eng
 
 		t->readFromXML(transformElement);
 		delete transformElement;
+	}
+
+	XmlElement * lightElement = entity->firstChild("light");
+	if(lightElement != NULL) {
+		std::cout << "   - Adding Light" << std::endl;
+		Light * light = engine->getLightManager()->getComponent(entityID);
+		if(light == NULL) {
+			Light temp = Light();
+			engine->addLight(entityID,temp);
+			light = engine->getLightManager()->getComponent(entityID);
+		}
+
+		light->readFromXML(lightElement);
+		delete lightElement;
 	}
 }
 

--- a/source/LevelLoader/LevelLoader.cpp
+++ b/source/LevelLoader/LevelLoader.cpp
@@ -77,6 +77,12 @@ void LevelLoader::loadEntity(XmlElement * entity, Scene * scene, ECSEngine * eng
 		std::string meshAsString(meshName);
 		entityID = scene->populateByName(meshAsString,engine);
 		addedFromFile = true;
+		Renderable * renderable = engine->getRenderableManager()->getComponent(entityID);
+		if(renderable != NULL) {
+			renderable->readFromXML(renderableElement);
+		}
+
+		
 		delete renderableElement;
 	}
 	else entityID = engine->addEntity();

--- a/source/LevelLoader/LevelLoader.cpp
+++ b/source/LevelLoader/LevelLoader.cpp
@@ -66,29 +66,45 @@ void LevelLoader::loadEntity(XmlElement * entity, Scene * scene, ECSEngine * eng
 	int entityID;
 	XmlElement * renderableElement = NULL;
 
+	bool addedFromFile = false;
+
 	renderableElement = entity->firstChild("renderable");
 	if(renderableElement != NULL) {
 		std::cout << "   - Adding Renderable" << std::endl;
 		char * meshName = NULL;
 		renderableElement->queryStringAttribute("meshName",(const char **) &meshName);
 		
-		std::cout << "meshname: " << meshName << std::endl;
 		std::string meshAsString(meshName);
 		entityID = scene->populateByName(meshAsString,engine);
-		std::cout << "entityID: " << entityID << std::endl;
-		//delete renderableElement;
+		addedFromFile = true;
+		delete renderableElement;
 	}
 	else entityID = engine->addEntity();
-	std::cout << "   - Added Renderable" << std::endl;
+	std::cout << "   - entityID: " << entityID << std::endl;
 
 	XmlElement * player = entity->firstChild("player");
 	if(player != NULL) {
 		std::cout << "   - Adding Player" << std::endl;
 		Player p = Player(entityID);
+
 		p.cameraOffset = 8;
 		engine->addPlayer(entityID,p);
 		verification.hasPlayer = true;
-		//delete player;
+		delete player;
+	}
+
+	XmlElement * transformElement = entity->firstChild("transform");
+	if(transformElement != NULL) {
+		std::cout << "   - Adding Transform" << std::endl;
+		Transform * t = engine->getTransformManager()->getComponent(entityID);
+		if(t == NULL) {
+			Transform temp = Transform();
+			engine->addTransform(entityID,temp);
+			t = engine->getTransformManager()->getComponent(entityID);
+		}
+
+		t->readFromXML(transformElement);
+		delete transformElement;
 	}
 }
 

--- a/source/ShaderManager.cpp
+++ b/source/ShaderManager.cpp
@@ -369,6 +369,7 @@ int ShaderManager::testShadowsDirectional = -1;
 int ShaderManager::skinnedShadows = -1;
 int ShaderManager::displayParticles = -1;
 int ShaderManager::volumetricLightScattering = -1;
+int ShaderManager::skybox = -1;
 
 void ShaderManager::loadShaders(ShaderManager* sm)
 {
@@ -435,6 +436,10 @@ void ShaderManager::loadShaders(ShaderManager* sm)
 	std::string vlsVert = "Shaders/drawQuad.vert";
 	std::string vlsFrag = "Shaders/VolumetricLightScattering.frag";
 	volumetricLightScattering = sm->createProgram(vlsVert, vlsFrag);
+
+	std::string skyboxVert = "Shaders/deferredBasic.vert";
+	std::string skyboxFrag = "Shaders/Skybox.frag";
+	skybox = sm->createProgram(skyboxVert, skyboxFrag);
 
 	if( glGetError() != GL_NO_ERROR ) std::cout << "Error creating a shader" << std::endl;
 }


### PR DESCRIPTION
Components have been split into their own files instead of all being contained in one header file. XML Parser is functional and reading many of the components has been implemented. Correctly creating an occlusion map for Volumetric light scattering has been implemented, however the skybox shader must be manually set for the skybox mesh in the level xml file.